### PR TITLE
Resolve connection issues with debugHost

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.whispir</groupId>
   <artifactId>sdk</artifactId>
-  <version>2.2.1</version>
+  <version>2.2.2</version>
   <name>WhispirSDK</name>
   <description>Whispir SDK for the Whispir API. Simplifies development on the Whispir API for Java developers.</description>
   <url>https://whispir.io</url>

--- a/src/main/java/com/whispir/sdk/WhispirSDK.java
+++ b/src/main/java/com/whispir/sdk/WhispirSDK.java
@@ -402,6 +402,10 @@ public class WhispirSDK implements MessageHelper, WorkspaceHelper,
 		String scheme = getScheme(host);
 
 		url.append(scheme).append(host);
+		
+		if(this.debug) {
+			url.append("/api");
+		}
 
 		if ((workspaceId != null && !"".equals(workspaceId)) || resourceType.equals(WhispirSDKConstants.WORKSPACES_RESOURCE)) {
 			url.append("/workspaces/" + workspaceId);
@@ -521,6 +525,7 @@ public class WhispirSDK implements MessageHelper, WorkspaceHelper,
 			}
 
 		} catch (IOException e) {
+			e.printStackTrace();
 			System.err.println("Message Failed - Connection Error: "
 					+ e.getMessage());
 		} finally {

--- a/src/main/java/com/whispir/sdk/WhispirSDK.java
+++ b/src/main/java/com/whispir/sdk/WhispirSDK.java
@@ -140,6 +140,7 @@ public class WhispirSDK implements MessageHelper, WorkspaceHelper,
 
 	public void setDebugHost(String debugHost) {
 		if (!"".equals(debugHost)) {
+			debugHost = debugHost.replaceAll("/api", "");
 			this.debugHost = debugHost;
 			this.debug = true;
 		} else {
@@ -375,7 +376,7 @@ public class WhispirSDK implements MessageHelper, WorkspaceHelper,
 		request.setHeader("Accept", header);
 	}
 
-	private String getHost() {
+	public String getHost() {
 		if (debug) {
 			return this.debugHost;
 		} else {
@@ -493,7 +494,7 @@ public class WhispirSDK implements MessageHelper, WorkspaceHelper,
 									// Ended sleep. Continue.
 								}
 
-								response = client.execute(httpRequest);
+								response = client.execute(targetHost, httpRequest, context);
 								statusCode = response.getStatusLine()
 										.getStatusCode();
 							}

--- a/src/test/java/com/whispir/sdk/impl/tests/WorkspaceHelperImplTest.java
+++ b/src/test/java/com/whispir/sdk/impl/tests/WorkspaceHelperImplTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 

--- a/src/test/java/com/whispir/sdk/tests/WhispirSDKTest.java
+++ b/src/test/java/com/whispir/sdk/tests/WhispirSDKTest.java
@@ -143,4 +143,15 @@ public class WhispirSDKTest {
     // HTTP401 Unauthorized Access
     assertTrue(response.getStatusCode() == 401);
   }
+  
+  @Test
+  public void testDebugHost() throws WhispirSDKException {
+    this.whispirSDK.setApikey(TEST_API_KEY);
+    this.whispirSDK.setUsername(TEST_USERNAME);
+    this.whispirSDK.setPassword(TEST_PASSWORD);
+    this.whispirSDK.setDebugHost("sandbox.whispir.com/api");
+
+    // HTTP401 Unauthorized Access
+    assertTrue(this.whispirSDK.getHost().equals("sandbox.whispir.com"));
+  }
 }


### PR DESCRIPTION
debugHost must now only be a hostname, it cannot contain any path parameters.  As such, I've added '/api' automatically when in debug mode and added a stacktrace to IOException when executing the 'execute()' method.

Also updated the pom.xml to version 2.2.2.
